### PR TITLE
Simplified database relations to 1-server-structure

### DIFF
--- a/src/bundles/Voxen.Server/Endpoints/Channels/CreateChannel/CreateChannelEndpoint.cs
+++ b/src/bundles/Voxen.Server/Endpoints/Channels/CreateChannel/CreateChannelEndpoint.cs
@@ -27,11 +27,8 @@ public class CreateChannelEndpoint(IServerConfigurationProvider serverConfigurat
             return;
         }
 
-        var server = await serverConfigurationProvider.GetAsync(ct);
         var channel = new Channel
         {
-            Server = server,
-            ServerId = server.Id,
             Name = request.Name,
             CreatedAt = DateTime.UtcNow,
             Type = request.Type

--- a/src/bundles/Voxen.Server/Endpoints/Server/GetServerInfo/GetServerInfoEndpoint.cs
+++ b/src/bundles/Voxen.Server/Endpoints/Server/GetServerInfo/GetServerInfoEndpoint.cs
@@ -11,7 +11,7 @@ public sealed class GetServerInfoEndpoint(IServerConfigurationProvider serverCon
     /// <inheritdoc />
     public override void Configure()
     {
-        Get("/server/info");
+        Get("/server");
         AllowAnonymous();
     }
 

--- a/src/bundles/Voxen.Server/Endpoints/Users/CreateUser/CreateUserEndpoint.cs
+++ b/src/bundles/Voxen.Server/Endpoints/Users/CreateUser/CreateUserEndpoint.cs
@@ -21,12 +21,9 @@ public class CreateUserEndpoint(UserManager<User> userManager, IServerConfigurat
     /// <inheritdoc />
     public override async Task HandleAsync(CreateUserRequest request, CancellationToken ct)
     {
-        var server = await serverConfigurationProvider.GetAsync(ct);
         var user = new User
         {
             UserName = request.Username,
-            Server = server,
-            ServerId = server.Id,
             Role = ServerRole.Member
         };
         

--- a/src/bundles/Voxen.Server/Entities/Channel.cs
+++ b/src/bundles/Voxen.Server/Entities/Channel.cs
@@ -4,42 +4,33 @@ using Voxen.Server.Enums;
 namespace Voxen.Server.Entities;
 
 /// <summary>
-/// Represents a communication channel within a server.
+/// Represents a communication channel.
 /// </summary>
 public class Channel
 {
     /// <summary>
-    /// Gets or sets the unique identifier for the channel.
+    /// Unique identifier for the channel.
     /// </summary>
     public Guid Id { get; set; }
 
     /// <summary>
-    /// Gets or sets the unique identifier of the server associated with this channel.
+    /// Channel name.
     /// </summary>
-    public Guid ServerId { get; set; }
-    
-    /// <summary>
-    /// Gets or sets the server associated with this channel.
-    /// </summary>
-    public Server Server { get; set; } = null!;
+    public required string Name { get; set; }
 
     /// <summary>
-    /// Gets or sets the name of the channel.
-    /// </summary>
-    public string Name { get; set; } = null!;
-
-    /// <summary>
-    /// Date and time when the server was created (stored in UTC).
+    /// Creation timestamp (UTC).
     /// </summary>
     public DateTime CreatedAt { get; set; }
 
     /// <summary>
-    /// Gets or sets the type of the channel.
+    /// Channel type.
     /// </summary>
     public ChannelType Type { get; set; }
 
     /// <summary>
-    /// Gets or sets the collection of messages associated with this channel.
+    /// Messages in the channel.
     /// </summary>
-    [JsonIgnore] public ICollection<Message>? Messages { get; set; }
+    [JsonIgnore]
+    public ICollection<Message> Messages { get; set; } = new List<Message>();
 }

--- a/src/bundles/Voxen.Server/Entities/Message.cs
+++ b/src/bundles/Voxen.Server/Entities/Message.cs
@@ -1,17 +1,43 @@
 namespace Voxen.Server.Entities;
 
 
+/// <summary>
+/// Represents a message sent by a user within a channel.
+/// </summary>
 public class Message
 {
+    /// <summary>
+    /// Gets or sets the unique identifier for the message.
+    /// </summary>
     public Guid Id { get; set; }
 
+    /// <summary>
+    /// Gets or sets the unique identifier of the channel in which the message was sent.
+    /// </summary>
     public Guid ChannelId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the channel in which the message was sent.
+    /// </summary>
     public Channel Channel { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets the unique identifier of the user who sent the message.
+    /// </summary>
     public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user who sent the message.
+    /// </summary>
     public User User { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets the textual content of the message.
+    /// </summary>
     public required string Content { get; set; }
 
+    /// <summary>
+    /// Gets or sets the date and time when the message was created (stored in UTC).
+    /// </summary>
     public DateTime CreatedAt { get; set; }
 }

--- a/src/bundles/Voxen.Server/Entities/Message.cs
+++ b/src/bundles/Voxen.Server/Entities/Message.cs
@@ -1,5 +1,6 @@
 namespace Voxen.Server.Entities;
 
+
 public class Message
 {
     public Guid Id { get; set; }
@@ -7,9 +8,10 @@ public class Message
     public Guid ChannelId { get; set; }
     public Channel Channel { get; set; } = null!;
 
-    public Guid UserId { get; set; } = Guid.Empty;
+    public Guid UserId { get; set; }
     public User User { get; set; } = null!;
 
-    public string Content { get; set; } = null!;
+    public required string Content { get; set; }
+
     public DateTime CreatedAt { get; set; }
 }

--- a/src/bundles/Voxen.Server/Entities/Server.cs
+++ b/src/bundles/Voxen.Server/Entities/Server.cs
@@ -1,9 +1,8 @@
-using System.Text.Json.Serialization;
-
 namespace Voxen.Server.Entities;
 
 /// <summary>
-/// Represents a server entity.
+/// Represents the server configuration.
+/// Only one server exists per Voxen instance.
 /// </summary>
 public class Server
 {
@@ -11,37 +10,25 @@ public class Server
     /// Gets or sets the unique identifier for the server.
     /// </summary>
     public Guid Id { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the name of the server.
     /// </summary>
-    public string Name { get; set; }
-    
+    public required string Name { get; set; }
+
     /// <summary>
     /// Gets or sets the date and time when the server was created (stored in UTC).
     /// </summary>
     public DateTime CreatedAt { get; set; }
-    
+
     /// <summary>
-    /// Gets or sets the raw server logo bytes (e.g., PNG/JPEG).
+    /// Raw server logo bytes.
     /// </summary>
     public byte[]? Logo { get; set; }
-    
+
     /// <summary>
-    /// Gets or sets the MIME type for the <see cref="Logo"/> (e.g., image/png).
+    /// MIME type for the logo.
     /// </summary>
     public string? LogoContentType { get; set; }
-    
-    /// <summary>
-    /// Gets or sets the collection of users associated with the server.
-    /// </summary>
-    [JsonIgnore]
-    public ICollection<User> Users { get; set; } = new List<User>();
-    
-    /// <summary>
-    /// Gets or sets the collection of channels associated with the server.
-    /// </summary>
-    [JsonIgnore]
-    public ICollection<Channel> Channels { get; set; } = new List<Channel>();
 }
 

--- a/src/bundles/Voxen.Server/Entities/User.cs
+++ b/src/bundles/Voxen.Server/Entities/User.cs
@@ -4,27 +4,17 @@ using Voxen.Server.Enums;
 namespace Voxen.Server.Entities;
 
 /// <summary>
-/// Represents a user entity within the system.
+/// Represents a user within the Voxen server.
 /// </summary>
 public class User : IdentityUser<Guid>
 {
     /// <summary>
-    /// Gets or sets the unique identifier of the server associated with the user.
-    /// </summary>
-    public Guid ServerId { get; set; }
-    
-    /// <summary>
-    /// Gets or sets the server associated with the user.
-    /// </summary>
-    public Server Server { get; set; } = null!;
-
-    /// <summary>
-    /// Gets or sets the role of the user within the associated server.
+    /// Gets or sets the role of the user.
     /// </summary>
     public ServerRole Role { get; set; }
 
     /// <summary>
-    /// Gets or sets the collection of messages associated with the user.
+    /// Messages sent by the user.
     /// </summary>
     public ICollection<Message> Messages { get; set; } = new List<Message>();
 }

--- a/src/bundles/Voxen.Server/Migrations/20260316095939_InitialCreate.Designer.cs
+++ b/src/bundles/Voxen.Server/Migrations/20260316095939_InitialCreate.Designer.cs
@@ -11,14 +11,14 @@ using Voxen.Server;
 namespace Voxen.Server.Migrations
 {
     [DbContext(typeof(VoxenDbContext))]
-    [Migration("20260313135904_InitialCreate")]
+    [Migration("20260316095939_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.3");
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.5");
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", b =>
                 {
@@ -159,15 +159,10 @@ namespace Voxen.Server.Migrations
                         .IsRequired()
                         .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ServerId")
-                        .HasColumnType("TEXT");
-
                     b.Property<int>("Type")
                         .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("ServerId");
 
                     b.ToTable("Channels");
 
@@ -275,9 +270,6 @@ namespace Voxen.Server.Migrations
                     b.Property<string>("SecurityStamp")
                         .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ServerId")
-                        .HasColumnType("TEXT");
-
                     b.Property<bool>("TwoFactorEnabled")
                         .HasColumnType("INTEGER");
 
@@ -293,8 +285,6 @@ namespace Voxen.Server.Migrations
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
                         .HasDatabaseName("UserNameIndex");
-
-                    b.HasIndex("ServerId");
 
                     b.ToTable("AspNetUsers", (string)null);
                 });
@@ -350,17 +340,6 @@ namespace Voxen.Server.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Voxen.Server.Entities.Channel", b =>
-                {
-                    b.HasOne("Voxen.Server.Entities.Server", "Server")
-                        .WithMany("Channels")
-                        .HasForeignKey("ServerId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Server");
-                });
-
             modelBuilder.Entity("Voxen.Server.Entities.Message", b =>
                 {
                     b.HasOne("Voxen.Server.Entities.Channel", "Channel")
@@ -380,27 +359,9 @@ namespace Voxen.Server.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("Voxen.Server.Entities.User", b =>
-                {
-                    b.HasOne("Voxen.Server.Entities.Server", "Server")
-                        .WithMany("Users")
-                        .HasForeignKey("ServerId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Server");
-                });
-
             modelBuilder.Entity("Voxen.Server.Entities.Channel", b =>
                 {
                     b.Navigation("Messages");
-                });
-
-            modelBuilder.Entity("Voxen.Server.Entities.Server", b =>
-                {
-                    b.Navigation("Channels");
-
-                    b.Navigation("Users");
                 });
 
             modelBuilder.Entity("Voxen.Server.Entities.User", b =>

--- a/src/bundles/Voxen.Server/Migrations/20260316095939_InitialCreate.cs
+++ b/src/bundles/Voxen.Server/Migrations/20260316095939_InitialCreate.cs
@@ -26,6 +26,46 @@ namespace Voxen.Server.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Role = table.Column<int>(type: "INTEGER", nullable: false),
+                    UserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
+                    PasswordHash = table.Column<string>(type: "TEXT", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "TEXT", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "TEXT", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Channels",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    Type = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Channels", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Server",
                 columns: table => new
                 {
@@ -57,60 +97,6 @@ namespace Voxen.Server.Migrations
                         name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
                         column: x => x.RoleId,
                         principalTable: "AspNetRoles",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "AspNetUsers",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
-                    ServerId = table.Column<Guid>(type: "TEXT", nullable: false),
-                    Role = table.Column<int>(type: "INTEGER", nullable: false),
-                    UserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
-                    NormalizedUserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
-                    Email = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
-                    NormalizedEmail = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
-                    EmailConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
-                    PasswordHash = table.Column<string>(type: "TEXT", nullable: true),
-                    SecurityStamp = table.Column<string>(type: "TEXT", nullable: true),
-                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: true),
-                    PhoneNumber = table.Column<string>(type: "TEXT", nullable: true),
-                    PhoneNumberConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
-                    TwoFactorEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
-                    LockoutEnd = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
-                    LockoutEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
-                    AccessFailedCount = table.Column<int>(type: "INTEGER", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_AspNetUsers_Server_ServerId",
-                        column: x => x.ServerId,
-                        principalTable: "Server",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "Channels",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
-                    ServerId = table.Column<Guid>(type: "TEXT", nullable: false),
-                    Name = table.Column<string>(type: "TEXT", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
-                    Type = table.Column<int>(type: "INTEGER", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Channels", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_Channels_Server_ServerId",
-                        column: x => x.ServerId,
-                        principalTable: "Server",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
@@ -259,20 +245,10 @@ namespace Voxen.Server.Migrations
                 column: "NormalizedEmail");
 
             migrationBuilder.CreateIndex(
-                name: "IX_AspNetUsers_ServerId",
-                table: "AspNetUsers",
-                column: "ServerId");
-
-            migrationBuilder.CreateIndex(
                 name: "UserNameIndex",
                 table: "AspNetUsers",
                 column: "NormalizedUserName",
                 unique: true);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Channels_ServerId",
-                table: "Channels",
-                column: "ServerId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Messages_ChannelId",
@@ -307,6 +283,9 @@ namespace Voxen.Server.Migrations
                 name: "Messages");
 
             migrationBuilder.DropTable(
+                name: "Server");
+
+            migrationBuilder.DropTable(
                 name: "AspNetRoles");
 
             migrationBuilder.DropTable(
@@ -314,9 +293,6 @@ namespace Voxen.Server.Migrations
 
             migrationBuilder.DropTable(
                 name: "Channels");
-
-            migrationBuilder.DropTable(
-                name: "Server");
         }
     }
 }

--- a/src/bundles/Voxen.Server/Migrations/VoxenDbContextModelSnapshot.cs
+++ b/src/bundles/Voxen.Server/Migrations/VoxenDbContextModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace Voxen.Server.Migrations
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.3");
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.5");
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", b =>
                 {
@@ -156,15 +156,10 @@ namespace Voxen.Server.Migrations
                         .IsRequired()
                         .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ServerId")
-                        .HasColumnType("TEXT");
-
                     b.Property<int>("Type")
                         .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("ServerId");
 
                     b.ToTable("Channels");
 
@@ -272,9 +267,6 @@ namespace Voxen.Server.Migrations
                     b.Property<string>("SecurityStamp")
                         .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ServerId")
-                        .HasColumnType("TEXT");
-
                     b.Property<bool>("TwoFactorEnabled")
                         .HasColumnType("INTEGER");
 
@@ -290,8 +282,6 @@ namespace Voxen.Server.Migrations
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
                         .HasDatabaseName("UserNameIndex");
-
-                    b.HasIndex("ServerId");
 
                     b.ToTable("AspNetUsers", (string)null);
                 });
@@ -347,17 +337,6 @@ namespace Voxen.Server.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Voxen.Server.Entities.Channel", b =>
-                {
-                    b.HasOne("Voxen.Server.Entities.Server", "Server")
-                        .WithMany("Channels")
-                        .HasForeignKey("ServerId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Server");
-                });
-
             modelBuilder.Entity("Voxen.Server.Entities.Message", b =>
                 {
                     b.HasOne("Voxen.Server.Entities.Channel", "Channel")
@@ -377,27 +356,9 @@ namespace Voxen.Server.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("Voxen.Server.Entities.User", b =>
-                {
-                    b.HasOne("Voxen.Server.Entities.Server", "Server")
-                        .WithMany("Users")
-                        .HasForeignKey("ServerId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Server");
-                });
-
             modelBuilder.Entity("Voxen.Server.Entities.Channel", b =>
                 {
                     b.Navigation("Messages");
-                });
-
-            modelBuilder.Entity("Voxen.Server.Entities.Server", b =>
-                {
-                    b.Navigation("Channels");
-
-                    b.Navigation("Users");
                 });
 
             modelBuilder.Entity("Voxen.Server.Entities.User", b =>

--- a/src/bundles/Voxen.Server/Services/SeedData.cs
+++ b/src/bundles/Voxen.Server/Services/SeedData.cs
@@ -35,7 +35,6 @@ public static class SeedData
         {
             Id = Guid.NewGuid(),
             UserName = "admin",
-            ServerId = defaultServer.Id,
             Role = ServerRole.Admin
         };
 

--- a/src/bundles/Voxen.Server/VoxenDbContext.cs
+++ b/src/bundles/Voxen.Server/VoxenDbContext.cs
@@ -14,14 +14,10 @@ public class VoxenDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     public DbSet<Channel> Channels => Set<Channel>();
     public DbSet<Message> Messages => Set<Message>();
 
+    /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
-
-        builder.Entity<User>()
-            .HasOne(u => u.Server)
-            .WithMany(s => s.Users)
-            .HasForeignKey(u => u.ServerId);
 
         builder.Entity<Channel>()
             .HasDiscriminator(c => c.Type)
@@ -31,11 +27,13 @@ public class VoxenDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
         builder.Entity<Message>()
             .HasOne(m => m.Channel)
             .WithMany(c => c.Messages)
-            .HasForeignKey(m => m.ChannelId);
+            .HasForeignKey(m => m.ChannelId)
+            .OnDelete(DeleteBehavior.Cascade);
 
         builder.Entity<Message>()
             .HasOne(m => m.User)
             .WithMany(u => u.Messages)
-            .HasForeignKey(m => m.UserId);
+            .HasForeignKey(m => m.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }


### PR DESCRIPTION
Since we are hosting the server in a containerized context, the need to support multiple servers on 1 instance becomes redundant. 

The current (and better) setup allows multiple containers on the same machine, where each container would have it's own IP and port and isolated container, and also allows individual domains behind a reverse proxy. 

This change simplifies the database relation needs, as the `Server` entity now becomes a simple set of metadata. This also improves security and simplifies authentication, as access to 1 server doesn't expose the database of multiple servers.